### PR TITLE
chore: make textExistsInALine function process multiple values

### DIFF
--- a/docker-functions.sh
+++ b/docker-functions.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Function to extract the base image from a filtered Dockerfile string
+# This string contains entries of all the lines starting with FROM
+getBaseImageFromFilteredDockerfile() {
+  local allFromEntries="$1"
+  local base_img
+
+  while IFS= read -r line; do
+    base_img=$(echo "$line" | grep '^FROM ' | awk '{print $2}')
+  done <<< "$allFromEntries"
+
+  echo "${base_img}"
+}

--- a/file-functions.sh
+++ b/file-functions.sh
@@ -24,6 +24,12 @@ function getLineForAString() {
 function textExistsInALine(){
     LINE="$1"
     TEXT="$2"
-    echo ${LINE}  | grep -q ${TEXT}
-    echo $?
+    # Split single comma separated string into array
+    IFS="," read -r -a TEXT_ARRAY <<< "$TEXT"
+    for ITEM in "${TEXT_ARRAY[@]}"; do
+        if [ "$ITEM" == "$LINE" ]; then
+            return 0
+        fi
+    done
+    return 1
 }

--- a/file-functions.sh
+++ b/file-functions.sh
@@ -11,14 +11,14 @@ function isFileExist() {
 function fileContainsString() {
     FILEPATH=$1
     TEXT="$2"
-    grep -q ${TEXT} ${FILEPATH}
+    grep -q "${TEXT}" "${FILEPATH}"
     echo $?
 }
 
 function getLineForAString() {
     FILEPATH=$1
     TEXT=$2
-    grep ${TEXT} ${FILEPATH} 
+    grep "${TEXT}" "${FILEPATH} "
 }
 
 function textExistsInALine(){


### PR DESCRIPTION
Also adds quotes around variables as suggested after running shellcheck.